### PR TITLE
支持 Docker 部署

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+node_modules

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM node:lts-alpine AS Builder
+WORKDIR /app
+COPY package*.json ./
+RUN npm install --registry=registry.npm.taobao.org
+COPY . .
+RUN npm run build
+
+FROM nginx:stable-alpine
+# 用本地的配置文件替换 nginx 镜像里的默认配置
+COPY deploy/default.conf /etc/nginx/conf.d/default.conf
+# 将发布好的目录复制到容器 nginx 默认目录
+COPY --from=Builder /app/dist /usr/share/nginx/html/
+
+CMD ["nginx", "-g", "daemon off;"]

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+local_port=8080
+docker_port=8080
+docker_tag=vue-hr
+
+containerId=$(docker ps -a | grep -w "${docker_tag}" | awk '{print $1}')
+if [ "$containerId" != "" ] ;
+then
+  # 停掉容器
+  docker stop "$containerId"
+  # 删除容器
+  docker rm "$containerId"
+  echo "成功删除容器"
+fi
+
+# 查询镜像是否存在，存在则删除
+imageId=$(docker images | grep -w "${docker_tag}" | awk '{print $3}')
+if [ "$imageId" != "" ] ;
+then
+  # 删除镜像
+  docker rmi -f "$imageId"
+  echo "成功删除镜像"
+fi
+
+# 构建镜像
+docker build . -t ${docker_tag}
+echo '成功构建镜像'
+# 启动容器
+docker run -d -p ${local_port}:${docker_port} ${docker_tag}
+echo "容器${docker_tag}已成功启动"
+

--- a/deploy/default.conf
+++ b/deploy/default.conf
@@ -1,0 +1,14 @@
+server {
+    listen 8080;
+    server_name localhost;
+
+    location / {
+        root /usr/share/nginx/html;
+        index index.html index.htm;
+        try_files $uri $uri/ /index.html;
+    }
+
+    location /api {
+        proxy_pass http://123.249.26.49:8082;
+    }
+}

--- a/src/util/service.js
+++ b/src/util/service.js
@@ -6,7 +6,7 @@ import { ElMessage } from 'element-plus'
 let loadingObj = null
 const Service = axios.create({
     timeout:8000,
-    baseURL:"http://123.249.26.49:8082/api/",
+    baseURL:"/api/",
     headers:{
         "Content-type":"application/json;chartset=utf-8"
     }
@@ -43,7 +43,7 @@ export const post = config =>{
     return Service({
         ...config,
         method:"post",
-    
+
     })
 }
 //get请求

--- a/vue.config.js
+++ b/vue.config.js
@@ -2,4 +2,13 @@ const { defineConfig } = require('@vue/cli-service')
 module.exports = defineConfig({
   transpileDependencies: true,
   lintOnSave:false,
+  devServer: {
+    proxy: {
+      '/api': {
+        target: 'http://123.249.26.49:8082',
+        ws: true,
+        changeOrigin: true
+      }
+    }
+  }
 })


### PR DESCRIPTION
- 开发时，通过配置 `devServer` 解决跨域问题，`axios.baseURL` 使用 `/api/` 即可
- 开发完毕部署时，使用 nginx Docker 镜像部署，配置 nginx proxy_pass 解决跨域问题

部署步骤：
1. 将代码 `git clone ...` 至目标服务器
2. 运行 `./deploy.sh` 启动容器，:8080 端口查看效果